### PR TITLE
Delete Gear

### DIFF
--- a/US/Gear
+++ b/US/Gear
@@ -1,3 +1,0 @@
-Necro
-Rift
-Icescar


### PR DESCRIPTION
The server seems unneeded to me and maps can be played on their servers (deathmatch & destroy)
Commit to change Destroy rotations to invlude these maps: https://github.com/OvercastNetwork/Rotations/pull/16
