### PR TITLE
Remove avalanche, move ssb

### DIFF
--- a/US/Nostalgia
+++ b/US/Nostalgia
@@ -2,9 +2,9 @@ Airship Battle
 Medieval Warfare
 Cake Wars
 Race for Victory
+Spaceship Battles
 A Watery Grave
 Sand Wars
-Spaceship Battles
 Shroom Trip
 Fort Wars
-Avalanche
+


### PR DESCRIPTION
The first four maps listed on the rotation are the more popular maps, put space ship battles before sand wars since people generally do not like the remaining four maps (WG, SW, ST, and FW)Why avalanche should be removed A)There is rarely enough people for it to be played the way it should be B)Even when there are enough people to play it decently, no one wants to because its a bad map
