### PR TITLE
Get rid of Battle Ecliptica II

### DIFF
--- a/US/Mini04
+++ b/US/Mini04
@@ -5,4 +5,3 @@ Dynamo
 Woolirium
 Deepwind Jungle
 Empire
-Battle Ecliptica II


### PR DESCRIPTION
It is 1/2 the size of all the other maps in the rotation on Mini04. It should be saved for a "micro" server or setnexting.
