### PR TITLE
Re-add Rift, Necro and Icescar to Alpha EU (Vasqon request)

### DIFF
--- a/EU/Alpha
+++ b/EU/Alpha
@@ -8,6 +8,7 @@ Scrap Mettle
 Blocks DTC
 Moonlight Summit
 Wildwood Crevice
+Rift
 Bamboo Valley
 The 8th Law
 Crater of Secrets


### PR DESCRIPTION
As Vasqon requested here: https://oc.tc/forums/topics/536fff5012ca9571c802c75c?page=10
I actually think this is a good idea to have some gear maps on EU alpha rotations still since their isn't any gear server on EU.
