### PR TITLE
Update GS rotations on US and EU

### DIFF
--- a/EU/GS1
+++ b/EU/GS1
@@ -1,10 +1,12 @@
-GS: Quartz Mine
-GS: Twisted
-GS: Frozen Palace
-GS: Grassy Knoll
 GS: Splinter
-GS: Weeping Shadows
-GS: Prototype
+GS: Blocks
+GS: Frozen Palace
+GS: Nostalgia
+GS: Quartz Mine
+GS: Whirlpool
+GS: Fairyland
 GS: Classic Flame
-GS: Desolated
+GS: Royal Garden
+GS: After the War
 GS: Vengeance
+GS: Deserted

--- a/EU/GS2
+++ b/EU/GS2
@@ -1,10 +1,12 @@
-GS: Twisted
-GS: Vengeance
-GS: Weeping Shadows
-GS: Grassy Knoll
 GS: Splinter
+GS: Whirlpool
+GS: Nostalgia
+GS: After the War
 GS: Frozen Palace
-GS: Classic Flame
-GS: Prototype
-GS: Desolated
+GS: Deserted
+GS: Royal Garden
 GS: Quartz Mine
+GS: Blocks
+GS: Fairyland
+GS: Vengeance
+GS: Classic Flame

--- a/EU/GS3
+++ b/EU/GS3
@@ -1,10 +1,12 @@
-GS: Quartz Mine
-GS: Twisted
-GS: Weeping Shadows
-GS: Classic Flame
-GS: Frozen Palace
 GS: Splinter
-GS: Prototype
-GS: Grassy Knoll
-GS: Desolated
+GS: Blocks
+GS: Frozen Palace
+GS: Nostalgia
+GS: Classic Flame
+GS: Deserted
+GS: Fairyland
+GS: Quartz Mine
+GS: Whirlpool
+GS: After the War
+GS: Royal Garden
 GS: Vengeance

--- a/EU/GS4
+++ b/EU/GS4
@@ -1,10 +1,12 @@
-GS: Quartz Mine
-GS: Twisted
-GS: Weeping Shadows
-GS: Classic Flame
 GS: Frozen Palace
+GS: Fairyland
+GS: After the War
+GS: Classic Flame
+GS: Deserted
+GS: Blocks
+GS: Quartz Mine
+GS: Nostalgia
+GS: Royal Garden
+GS: Whirlpool
 GS: Splinter
-GS: Prototype
-GS: Grassy Knoll
-GS: Desolated
 GS: Vengeance

--- a/US/GS1
+++ b/US/GS1
@@ -1,10 +1,12 @@
-GS: Classic Flame
-GS: Grassy Knoll
-GS: Weeping Shadows
-GS: Twisted
-GS: Quartz Mine
-GS: Frozen Palace
+GS: Nostalgia
+GS: After the War
+GS: Deserted
+GS: Royal Garden
 GS: Splinter
+GS: Quartz Mine
+GS: Classic Flame
+GS: Whirlpool
 GS: Vengeance
-GS: Prototype
-GS: Desolated
+GS: Blocks
+GS: Frozen Palace
+GS: Fairyland

--- a/US/GS2
+++ b/US/GS2
@@ -1,10 +1,12 @@
-GS: Classic Flame
-GS: Grassy Knoll
-GS: Weeping Shadows
-GS: Twisted
-GS: Quartz Mine
-GS: Frozen Palace
 GS: Splinter
+GS: After the War
+GS: Classic Flame
+GS: Frozen Palace
+GS: Fairyland
+GS: Quartz Mine
+GS: Royal Garden
+GS: Nostalgia
+GS: Whirlpool
+GS: Blocks
 GS: Vengeance
-GS: Prototype
-GS: Desolated
+GS: Deserted

--- a/US/GS3
+++ b/US/GS3
@@ -1,10 +1,12 @@
-GS: Splinter
-GS: Desolated
-GS: Classic Flame
-GS: Prototype
-GS: Twisted
-GS: Frozen Palace
-GS: Grassy Knoll
+GS: Nostalgia
+GS: Blocks
 GS: Vengeance
-GS: Weeping Shadows
+GS: Royal Garden
+GS: Deserted
+GS: Frozen Palace
+GS: Fairyland
+GS: Whirlpool
 GS: Quartz Mine
+GS: Splinter
+GS: After the War
+GS: Classic Flame

--- a/US/GS4
+++ b/US/GS4
@@ -1,10 +1,12 @@
-GS: Splinter
-GS: Vengeance
-GS: Prototype
-GS: Grassy Knoll
-GS: Twisted
-GS: Frozen Palace
+GS: Fairyland
 GS: Quartz Mine
+GS: Vengeance
+GS: Frozen Palace
 GS: Classic Flame
-GS: Desolated
-GS: Weeping Shadows
+GS: Blocks
+GS: Deserted
+GS: Splinter
+GS: Nostalgia
+GS: Whirlpool
+GS: Royal Garden
+GS: After the War

--- a/US/GS5
+++ b/US/GS5
@@ -1,10 +1,12 @@
-GS: Desolated
-GS: Grassy Knoll
-GS: Prototype
-GS: Vengeance
-GS: Weeping Shadows
-GS: Quartz Mine
-GS: Frozen Palace
 GS: Splinter
-GS: Twisted
+GS: Nostalgia
+GS: After the War
+GS: Vengeance
+GS: Royal Garden
+GS: Frozen Palace
+GS: Blocks
 GS: Classic Flame
+GS: Whirlpool
+GS: Quartz Mine
+GS: Fairyland
+GS: Deserted

--- a/US/GS6
+++ b/US/GS6
@@ -1,10 +1,12 @@
-GS: Classic Flame
-GS: Grassy Knoll
-GS: Weeping Shadows
-GS: Twisted
-GS: Frozen Palace
-GS: Quartz Mine
-GS: Vengeance
-GS: Desolated
-GS: Prototype
 GS: Splinter
+GS: Nostalgia
+GS: Blocks
+GS: Quartz Mine
+GS: Royal Garden
+GS: Whirlpool
+GS: After the War
+GS: Frozen Palace
+GS: Vengeance
+GS: Fairyland
+GS: Deserted
+GS: Classic Flame


### PR DESCRIPTION
So after receiving ratings from the form I made and the official map ratings, I have crafted a new rot.

Added:
- GS: After the War
- GS: Fairyland
- GS: Royal Garden
- GS: Nostalgia
- GS: Whirlpool
- GS: Blocks
- GS: Deserted

Kept:
- GS: Vengeance
- GS: Splinter
- GS: Classic Flame
- GS: Frozen Palace
- GS: Quartz Mine

Removed:
- GS: Desolated
- GS: Twisted
- GS: Prototype
- GS: Grassy Knoll

I removed the maps that had poor gameplay/design and added in a lot more new maps to bring in some 'freshness' and hopefully encourage more people to make GS maps.
