### PR TITLE
Update Capture1 [Rebase]

### DIFF
--- a/US/Capture1
+++ b/US/Capture1
@@ -1,12 +1,14 @@
 Fairy Tales 2: A Tale or Two
 Golden Drought
+Argon
 Jungle Beat
-Mushroom Gorge
+Exitium
 Race for Victory 2
 Ring Race
-Tenebrous
-Battle Ecliptica III
+Havoc
 Two Tier
 Bamboo Valley
 A New Day
 Pursuit of Happiness
+Hydrolock
+Empire


### PR DESCRIPTION
I was told by MonsieurApple to rebase my PR, so here I am.

I do not like some of the maps on the current rotation so I decided to do a little change. First, I believed the rotation needed more maps, so I added some. I took out Mushroom Gorge because the void gap is excessively long. If it were shorter, it would be a much better map. Battle Ecliptica III has a nice twist to it, but the lanes are very short, and it is very easy to prevent people from getting to a wool room. Also, you cannot place along the side of the lanes without block glitching. The lanes are also a bit thin. I removed Tenebrous because of the force single-cap. And there is only one way to get into the wool room which is usually filled with about 11 per lane. Also, I spaced out the maps that were in the rotations before. Having the maps from the older rotations play one after another gives the feel of the old rotation and gets boring because of the amount of times the map was played before. 

[Hydrolock Suggestion] I added Hydrolock even if it can be rushed easily. I believe that having it every once in a while isn't that bad, considering a lot of the other maps take a long time to finish. It would be better if the water was void and the flame bows only had ten shots or so left. I understand the rushing problem, so there's my solution. People will be focused on frontlines instead of rushing with boats across the water.

Sorry for any mistakes made, I'm new to GitHub. If I am doing something wrong please tell me.
