### PR TITLE
Add Immitis to EU, and reorder rotation based on gamemode

### DIFF
--- a/EU/Mini02
+++ b/EU/Mini02
@@ -1,14 +1,15 @@
-BlockRAGE
 Academy
+BlockRAGE
 Abudor
 Blitzkrieg: TDM
 Aaeros
 Cloud Nine
 Facility
+Immitis
 Boom
-Dust
 SuperPRISM
 Sunburn
-Nightlife TDM
-Pharaoh's Catacombs
 Tebulas
+Nightlife TDM
+Dust
+Pharaoh's Catacombs

--- a/US/Mini03
+++ b/US/Mini03
@@ -1,15 +1,15 @@
-BlockRAGE
 Academy
+BlockRAGE
 Abudor
 Blitzkrieg: TDM
 Aaeros
 Cloud Nine
 Facility
-Boom
 Immitis
+Boom
 SuperPRISM
 Sunburn
+Tebulas
 Nightlife TDM
 Dust
 Pharaoh's Catacombs
-Tebulas


### PR DESCRIPTION
First of all, the EU rotation was _missing_ Immitis. It was only on the US rotation.

Second of all, I re-ordered the rotation so that there is never 2 of the same gamemode after eachother.
The old rotatiom had several KoTH, and RageTDM after eachother. I made it so that never happens, so it's a different gamemode between. I think that adds more variety.

Thoughts? If you scrap my "re-order of rotation", please still add Immitis to the EU Mini02 rotation. It's missing.
