### PR TITLE
Add missing map Aureola to EU

### DIFF
--- a/EU/Mini01
+++ b/EU/Mini01
@@ -8,6 +8,7 @@ Circus DTC
 Empire
 BalloonsDTM
 Snowy Wars
+Aureola
 Streamline
 Banana Split
 Antiquis


### PR DESCRIPTION
Aureola only existed on US Mini08, but not on any EU server.
