### PR TITLE
Add missing map AstroGEN to EU

### DIFF
--- a/EU/Mini06
+++ b/EU/Mini06
@@ -10,5 +10,6 @@ SuperPRISM
 Golden Drought III
 Aaeros
 Pirates Den
+AstroGEN
 Circus DTC
 Icy Peaks TDM


### PR DESCRIPTION
AstroGEN does not exist on any EU server, but it does on US Mini10.
