### PR TITLE
Add Dust to Mini04 EU and Mini06 US

### DIFF
--- a/EU/Mini04
+++ b/EU/Mini04
@@ -8,6 +8,7 @@ Pirates Den
 Facility
 Iris DTC
 Hot Dam: Mini
+Dust
 Deepwind Jungle
 Warlock
 Nightlife TDM

--- a/US/Mini06
+++ b/US/Mini06
@@ -6,6 +6,7 @@ Antiquis
 Blitzkrieg: TDM
 Boom
 Academy
+Dust
 BalloonsDTM
 Facility
 Cargo


### PR DESCRIPTION
This was added to 4 rots (2 on US and 2 on EU) just as this repo was open. SuperPRISM, Tebulas and other RageTDM's are in the rots 6 times (3 on US, 3 on EU) so it would be nice to balance it out. 

Dust has quite a high rating of 4.35/5 and seems to be liked by quite a lot of people. I made sure the team sizes flow nicely with other maps in the rots. 
