### PR TITLE
Remove Oculo from Rage rotations

### DIFF
--- a/EU/RAGE1
+++ b/EU/RAGE1
@@ -10,7 +10,6 @@ BipBetaMC
 Plus Side
 Grimsnes
 The 6th Law
-Oculo
 Sylvan
 Gooseberry
 101 Rooms
@@ -24,4 +23,3 @@ Plus Side
 Rage Quit
 Grimsnes
 The 6th Law
-Oculo

--- a/US/RAGE1
+++ b/US/RAGE1
@@ -10,7 +10,6 @@ BipBetaMC
 Plus Side
 Grimsnes
 The 6th Law
-Oculo
 Sylvan
 Gooseberry
 101 Rooms
@@ -24,4 +23,3 @@ Plus Side
 Rage Quit
 Grimsnes
 The 6th Law
-Oculo

--- a/US/RAGE2
+++ b/US/RAGE2
@@ -10,7 +10,6 @@ BipBetaMC
 Plus Side
 Grimsnes
 The 6th Law
-Oculo
 Sylvan
 Gooseberry
 101 Rooms
@@ -24,4 +23,3 @@ Plus Side
 Rage Quit
 Grimsnes
 The 6th Law
-Oculo


### PR DESCRIPTION
This map not only does not play well for players who have never played it before, but it also does not fit the style of the rest of the Rage rotations. It is never very fun to play, and--although it seems to have a high rating from the less than 1,000 people who have rated it--I don't think it belongs in our Rage rotations.
