### PR TITLE
Update Rage rotations on US and EU

### DIFF
--- a/EU/RAGE1
+++ b/EU/RAGE1
@@ -1,27 +1,21 @@
-101 Rooms
-Gravestone
-Rage Quit
-Fallen Courtyard
-Gooseberry
-Arid Crossroads
-Dry Wound
-Rage Quit
-BipBetaMC
-Plus Side
-Grimsnes
-The 6th Law
-Oculo
-Sylvan
-Gooseberry
-101 Rooms
-Arid Crossroads
-BipBetaMC
-Dry Wound
-Fallen Courtyard
-Gravestone
 Swarthmoor
-Plus Side
+Overgrown Rage
 Rage Quit
-Grimsnes
-The 6th Law
-Oculo
+Into The Jungle
+BipBetaMC
+101 Rooms
+Snow Globe
+Plus Side
+Arid Crossroads
+Arx Rage
+Sylvan
+Gravestone
+Fallen Courtyard
+Swarthmoor
+Rage Quit
+Rage Maze
+Plus Side
+Foxtrot
+BipBetaMC
+Dry Wound
+Arid Crossroads

--- a/US/RAGE1
+++ b/US/RAGE1
@@ -1,27 +1,21 @@
-101 Rooms
-Gravestone
-Rage Quit
-Fallen Courtyard
-Gooseberry
-Arid Crossroads
-Dry Wound
-Rage Quit
-BipBetaMC
 Plus Side
-Grimsnes
-The 6th Law
-Oculo
-Sylvan
-Gooseberry
-101 Rooms
-Arid Crossroads
-BipBetaMC
-Dry Wound
-Fallen Courtyard
+Snow Globe
+Foxtrot
 Gravestone
+101 Rooms
 Swarthmoor
-Plus Side
+Arid Crossroads
 Rage Quit
-Grimsnes
-The 6th Law
-Oculo
+Arx Rage
+BipBetaMC
+Into The Jungle
+Fallen Courtyard
+Rage Maze
+Plus Side
+Swarthmoor
+Sylvan
+Arid Crossroads
+Rage Quit
+Overgrown Rage
+Dry Wound
+BipBetaMC

--- a/US/RAGE2
+++ b/US/RAGE2
@@ -1,27 +1,21 @@
-101 Rooms
-Gravestone
-Rage Quit
-Fallen Courtyard
-Gooseberry
-Arid Crossroads
-Dry Wound
-Rage Quit
 BipBetaMC
 Plus Side
-Grimsnes
-The 6th Law
-Oculo
-Sylvan
-Gooseberry
-101 Rooms
-Arid Crossroads
-BipBetaMC
-Dry Wound
-Fallen Courtyard
-Gravestone
 Swarthmoor
-Plus Side
+Arid Crossroads
+Fallen Courtyard
 Rage Quit
-Grimsnes
-The 6th Law
-Oculo
+Dry Wound
+Arx Rage
+Into The Jungle
+Foxtrot
+BipBetaMC
+Snow Globe
+Plus Side
+Sylvan
+Swarthmoor
+Gravestone
+Rage Quit
+Arid Crossroads
+101 Rooms
+Rage Maze
+Overgrown Rage


### PR DESCRIPTION
_Updated: Fixed foxtrot and removed Ieats after second thoughts_

The following rotations were based on feedback from my form and from the official ratings.

Kept:
- Plus Side
- Gravestone
- 101 Rooms
- Swarthmoor
- Arid Crossroads
- Rage Quit
- BipBetaMC
- Fallen Courtyard
- Sylvan
- Dry Wound

Added:
- Snow Globe
- Foxtrot Rage
- Arx Rage
- Into The Jungle
- Rage Maze
- Overgrown Rage

Removed:
- Oculo
- The 6th Law
- Grimsnes
- Gooseberry

In rotation twice:
- Rage Quit
- Swarthmoor
- Arid Crossroads
- BipBetaMC
- Plus Side

I decided to have the classic/popular maps replayed. If you disagree on having some maps played twice, please let me know.
