### PR TITLE
Update Rage rotations on US and EU

### DIFF
--- a/EU/RAGE1
+++ b/EU/RAGE1
@@ -1,27 +1,19 @@
 101 Rooms
-Gravestone
-Rage Quit
-Fallen Courtyard
-Gooseberry
-Arid Crossroads
-Dry Wound
-Rage Quit
-BipBetaMC
-Plus Side
-Grimsnes
-The 6th Law
-Oculo
-Sylvan
-Gooseberry
-101 Rooms
-Arid Crossroads
-BipBetaMC
-Dry Wound
-Fallen Courtyard
-Gravestone
 Swarthmoor
+Ieats Hall
+Kozicu
+Proelium
+Fallen Courtyard
+Dry Wound
+Arx Rage
+Rage Maze
+Arid Crossroads
+Snow Globe
+Foxtrot
+Gooseberry
 Plus Side
+BipBetaMC
+Into The Jungle
+Mushrooms of Oblivion
+Gravestone
 Rage Quit
-Grimsnes
-The 6th Law
-Oculo

--- a/US/RAGE1
+++ b/US/RAGE1
@@ -1,27 +1,19 @@
-101 Rooms
-Gravestone
-Rage Quit
-Fallen Courtyard
-Gooseberry
+Foxtrot
 Arid Crossroads
-Dry Wound
-Rage Quit
-BipBetaMC
-Plus Side
-Grimsnes
-The 6th Law
-Oculo
-Sylvan
-Gooseberry
-101 Rooms
-Arid Crossroads
-BipBetaMC
-Dry Wound
 Fallen Courtyard
 Gravestone
+BipBetaMC
 Swarthmoor
-Plus Side
+Arx Rage
+Snow Globe
+Ieats Hall
+Kozicu
+Dry Wound
+Gooseberry
+Into The Jungle
 Rage Quit
-Grimsnes
-The 6th Law
-Oculo
+Plus Side
+Proelium
+101 Rooms
+Rage Maze
+Mushrooms of Oblivion

--- a/US/RAGE2
+++ b/US/RAGE2
@@ -1,27 +1,19 @@
-101 Rooms
-Gravestone
-Rage Quit
-Fallen Courtyard
-Gooseberry
-Arid Crossroads
+Mushrooms of Oblivion
 Dry Wound
-Rage Quit
-BipBetaMC
 Plus Side
-Grimsnes
-The 6th Law
-Oculo
-Sylvan
+Proelium
 Gooseberry
-101 Rooms
-Arid Crossroads
 BipBetaMC
-Dry Wound
+Snow Globe
 Fallen Courtyard
-Gravestone
+Arid Crossroads
+Ieats Hall
 Swarthmoor
-Plus Side
+Foxtrot
+Gravestone
+Kozicu
+Rage Maze
 Rage Quit
-Grimsnes
-The 6th Law
-Oculo
+Arx Rage
+101 Rooms
+Into The Jungle


### PR DESCRIPTION
New and improved. Decided not to have some maps play twice as it may be unfair on map makers who only have their map played once. 

Rotation is as follows:
- 101 Rooms
- Swarthmoor
- Ieats Hall
- Kozicu
- Proelium
- Fallen Courtyard
- Dry Wound
- Arx Rage
- Rage Maze
- Arid Crossroads
- Snow Globe
- Foxtrot
- Gooseberry
- Plus Side
- BipBetaMC
- Into The Jungle
- Mushrooms of Oblivion
- Gravestone
- Rage Quit

_Rotations vary on servers_
