### PR TITLE
Removing BlockRAGE

### DIFF
--- a/EU/Mini02
+++ b/EU/Mini02
@@ -1,5 +1,4 @@
 Academy
-BlockRAGE
 Abudor
 Blitzkrieg: TDM
 Aaeros

--- a/US/Mini03
+++ b/US/Mini03
@@ -1,5 +1,4 @@
 Academy
-BlockRAGE
 Abudor
 Blitzkrieg: TDM
 Aaeros

--- a/US/Mini08
+++ b/US/Mini08
@@ -1,4 +1,3 @@
-BlockRAGE
 Banana Split
 Boom
 Golden Drought III


### PR DESCRIPTION
Removing BlockRAGE until the map gets an update for the middle spawners.
As the map is rage the middle spawner is useless and makes players
believe the items there are better. I recommend having items such as
resistance potions in there so you can go on a small spree or stuff like
that. Maybe jump boost?
The second reason is there is no sword and players quickly get confused
(after playing it today and people said wheres the sword in chat).

Otherwise the map is good and I quite enjoy it just update it or if the
update will take a long time, remove it till then.
