### PR TITLE
add warlock to mini03 EU

### DIFF
--- a/EU/Mini03
+++ b/EU/Mini03
@@ -1,6 +1,7 @@
 Banana Split
 Cargo
 Golden Drought III
+Warlock
 Woolirium
 Deepwind Jungle
 Empire


### PR DESCRIPTION
Warlock appears 4 times on the US mini servers and only once the EU servers (Mini01). The map is personally one of my favorites and I feel that I am not alone when saying it should appear at least twice in the EU rots as Warlock rarely seems to play.
