### PR TITLE
add Warlock to mini06 EU

### DIFF
--- a/EU/Mini06
+++ b/EU/Mini06
@@ -1,6 +1,7 @@
 Atromix
 Sunburn
 Banana Split
+Warlock
 Discipline
 Hot Dam: Mini
 Blitzkrieg: TDM


### PR DESCRIPTION
Warlock appears 4 times on the US mini servers and only twice on the EU servers (Mini01 and Mini04). The map is personally one of my favorites and I feel that I am not alone when saying it should appear more frequently in the EU rots as Warlock rarely seems to play.
