### PR TITLE
Remove Iris DTC

### DIFF
--- a/EU/Mini04
+++ b/EU/Mini04
@@ -6,7 +6,6 @@ SolitudeMC
 Facility
 Sunrise Over Paradise
 Discipline
-Iris DTC
 Deepwind Jungle
 Nightlife TDM
 Coastline

--- a/EU/Mini05
+++ b/EU/Mini05
@@ -3,7 +3,6 @@ Aaeros
 Woolirium
 Cargo
 Lemuria
-Iris DTC
 Boom
 Antiquis
 Facility

--- a/US/Mini02
+++ b/US/Mini02
@@ -8,4 +8,3 @@ Banana Split
 BalloonsDTM
 The Fenland
 Empire
-Iris DTC

--- a/US/Mini06
+++ b/US/Mini06
@@ -1,5 +1,4 @@
 Tebulas
-Iris DTC
 Woolirium
 Abudor
 Antiquis

--- a/US/Mini07
+++ b/US/Mini07
@@ -4,7 +4,6 @@ Streamline
 Woolirium
 Sunrise Over Paradise
 Facility
-Iris DTC
 Lava Dew
 Hot Dam: Mini
 Deepwind Jungle


### PR DESCRIPTION
Current rating is 3.06, about as low as it gets. Not a bad map, but very badly suited to public rotations. The map is very large and complex, and the core is hard to find.
