### PR TITLE
Add Primed (EU)

### DIFF
--- a/EU/Primed
+++ b/EU/Primed
@@ -1,0 +1,16 @@
+BoomBox
+Medieval Warfare
+Retaliation 2
+Totally War II
+Astro
+Retaliation
+cos(tnt)
+Fortress Battles
+DATAstation
+Bamboo Valley III
+Interitus
+Airship Battle
+Spaceship Battles
+Fractal Descent
+Iris DTC
+State of Decay II


### PR DESCRIPTION
I understand why EU does not have Gear because of the low player count but maps like cos and boombox are very likable and the player count is good even if added to EU.
