### PR TITLE
Re-order primed and remove two maps

### DIFF
--- a/US/Primed
+++ b/US/Primed
@@ -1,4 +1,3 @@
-Astro
 Totally War II
 Fortress Battles
 Fractal Descent


### PR DESCRIPTION
This PR re-orders the Primed rotation so team sizes aren't a drastic change. This also removes Iris DTC and State of Decay II. Iris was recently removed from all the other servers due to very poor ratings and State of Decay II doesn't really fit well with the rest of the maps on Primed. Decay has some TNT but it isn't really used and is more of a standard DTM you would find on Destroy or Alpha.
