### PR TITLE
Update Blitz Rotations on US and EU

### DIFF
--- a/EU/Chaos
+++ b/EU/Chaos
@@ -6,7 +6,7 @@ Abysm: Blitz
 Aqua Zero
 Osage
 Battle of Lyndanisse Blitz
-Relapse
+Relapse UHC
 The Complex
 Blitzkrieg
 Drow's Crevice: Blitz

--- a/US/Chaos
+++ b/US/Chaos
@@ -6,7 +6,7 @@ Abysm: Blitz
 Aqua Zero
 Osage
 Battle of Lyndanisse Blitz
-Relapse
+Relapse UHC
 The Complex
 Blitzkrieg
 Drow's Crevice: Blitz

--- a/US/Cronus
+++ b/US/Cronus
@@ -6,7 +6,7 @@ Abysm: Blitz
 Aqua Zero
 Osage
 Battle of Lyndanisse Blitz
-Relapse
+Relapse UHC
 The Complex
 Blitzkrieg
 Drow's Crevice: Blitz


### PR DESCRIPTION
So yeah, I decided to update the Blitz rotation again with brand new maps. The rotation is as follows:
- Blitzkrieg
- The Complex
- Dry Gulch
- Aqua Zero
- Osage
- Drow's Crevice: Blitz
- Deadwater Docks
- Bliss
- Arbaro Blitz
- CotBot
- Abysm: Blitz
- No Return
- Dust: Blitz
- Battle of Lyndanisse Blitz
- Relapse
- Aerugo
- The Arena Blitz
- Lost Woods
- Abandoned Zoo Blitz

Feedback is much appreciated!
