### PR TITLE
Remove Totally War II

### DIFF
--- a/US/Primed
+++ b/US/Primed
@@ -1,4 +1,3 @@
-Totally War II
 Bamboo Valley III
 Fractal Descent
 Retaliation


### PR DESCRIPTION
Not only does this map have odd spawnkits (no blocks?), and not only are the chests placed in very odd locations, but the gameplay is often poor and decreases over time, unlike newer maps such as BoomBox and cos(tnt) where the gameplay is consistent throughout the entire match. I feel that this map no longer deserves to be in the Primed rotations, and would like your thoughts as well.
