### PR TITLE
Add Sand Wars: DTE

### DIFF
--- a/US/Primed
+++ b/US/Primed
@@ -1,3 +1,4 @@
+Sand Wars: DTE
 Blocks: Destroy the Dynamite
 Bamboo Valley III
 Fractal Descent


### PR DESCRIPTION
Currently rated 4.68 with only 19 votes, but the original Sand Wars has a 3.99 rating with over 5k votes, so it's a good bet that this map will be popular. It's also totally unique and a change of pace from the other maps.
