### PR TITLE
Update Rage rotations on US and EU

### DIFF
--- a/EU/RAGE1
+++ b/EU/RAGE1
@@ -1,18 +1,20 @@
+Gone Camping
+Aureola Rage
 101 Rooms
-Swarthmoor
+Cubed³
 Kozicu
-Proelium
-Fallen Courtyard
-Dry Wound
-Arx Rage
-Rage Maze
-Arid Crossroads
-Snow Globe
-Foxtrot
-Gooseberry
-Plus Side
+The 6th Law
 BipBetaMC
-Into The Jungle
-Mushrooms of Oblivion
-Gravestone
+The End
+Fallen Courtyard
 Rage Quit
+Gooseberry
+Proelium
+Plus Side
+Into The Jungle
+Foxtrot
+Bliss Rage
+Swarthmoor
+Quavilla
+Arid Crossroads
+Dry Wound

--- a/US/RAGE1
+++ b/US/RAGE1
@@ -1,18 +1,20 @@
-Foxtrot
-Arid Crossroads
-Fallen Courtyard
-Gravestone
-BipBetaMC
-Swarthmoor
-Arx Rage
-Snow Globe
-Kozicu
-Dry Wound
-Gooseberry
-Into The Jungle
-Rage Quit
-Plus Side
-Proelium
+Gone Camping
+Aureola Rage
 101 Rooms
-Rage Maze
-Mushrooms of Oblivion
+Cubed³
+Kozicu
+The 6th Law
+BipBetaMC
+The End
+Fallen Courtyard
+Rage Quit
+Gooseberry
+Proelium
+Plus Side
+Into The Jungle
+Foxtrot
+Bliss Rage
+Swarthmoor
+Quavilla
+Arid Crossroads
+Dry Wound

--- a/US/RAGE2
+++ b/US/RAGE2
@@ -1,18 +1,20 @@
-Mushrooms of Oblivion
-Dry Wound
-Plus Side
-Proelium
-Gooseberry
-BipBetaMC
-Snow Globe
-Fallen Courtyard
-Arid Crossroads
-Swarthmoor
-Foxtrot
-Gravestone
-Kozicu
-Rage Maze
-Rage Quit
-Arx Rage
 101 Rooms
+Aureola Rage
+Dry Wound
+Gooseberry
+Quavilla
+Cubed³
+The 6th Law
+Foxtrot
 Into The Jungle
+Bliss Rage
+Fallen Courtyard
+Proelium
+Rage Quit
+The End
+Kozicu
+Gone Camping
+Swarthmoor
+Arid Crossroads
+BipBetaMC
+Plus Side


### PR DESCRIPTION
Updates to the rage rotation:
- Gone Camping
- Aureola Rage
- 101 Rooms
- Cubed³
- Kozicu
- The 6th Law
- BipBetaMC
- The End
- Fallen Courtyard
- Rage Quit
- Gooseberry
- Proelium
- Plus Side
- Into The Jungle
- Foxtrot
- Bliss Rage
- Swarthmoor
- Quavilla
- Arid Crossroads
- Dry Wound

Feedback is much appreciated!
