### PR TITLE
Update Control rots on US and EU

### DIFF
--- a/EU/Control
+++ b/EU/Control
@@ -10,6 +10,7 @@ Aztecatti
 TF2 Badlands
 Nucleus
 Lost World: CTP
+Discipline
 CatalystCP
 Equinox
 Abudor II

--- a/US/Control
+++ b/US/Control
@@ -10,6 +10,7 @@ Aztecatti
 TF2 Badlands
 Nucleus
 Lost World: CTP
+Discipline
 CatalystCP
 Equinox
 Abudor II


### PR DESCRIPTION
My final rotation update. The rotation has a nice flow to it so player caps gradually get lower, then higher. To the right of the map name is the max player cap.
- Sinuous (70)
- Diablo (64)
- Green Hill Zone (64)
- Piston KOTH (64)
- The Hill (60)
- Urban Jungle (48)
- Valley of the Dead (48)
- cos(tnt) (48)
- Aztecatti (32)
- TF2 Badlands (20)
- Nucleus (20)
- Lost World: CTP (20)
- CatalystCP (36)
- Equinox (40)
- Abudor II (40)
- Aaeros (40)
- Cat's Cradle (64)

Feedback is appreciated!

**Don't merge this until itemkeep stuff is fixed for VotD and Aztecatti**
