### PR TITLE
Update Deathmatch rotations on US and EU

### DIFF
--- a/EU/Deathmatch
+++ b/EU/Deathmatch
@@ -16,3 +16,4 @@ Scrap Mettle
 Babylon
 Arachnea
 Battle of Lyndanisse
+Remnant Souls

--- a/US/Deathmatch
+++ b/US/Deathmatch
@@ -16,3 +16,4 @@ Scrap Mettle
 Babylon
 Arachnea
 Battle of Lyndanisse
+Remnant Souls


### PR DESCRIPTION
The TDM rotations haven't been updated for a while so I decided to update them now. The rotation is as follows: 
- The Archives
- Stampede
- SuperPRISM
- The Arena
- BlockBlock
- Wildwood Crevice
- Sugar Rush
- Lights Out
- Tebulas
- Harb
- Abandoned Zoo
- Wooly Woods
- Lunar Coliseum
- Abysm: TDM
- Scrap Mettle
- Babylon
- Arachnea
- Battle of Lyndanisse
- Remnant Souls

Feedback and suggestions are appreciated! 
