### PR TITLE
Update to the new forum link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a listing of files which correspond to all public [Over
 You can suggest changes to the rotations by opening an [issue](https://github.com/OvercastNetwork/Rotations/issues) in this repository. Please make sure your request follows these guidelines:
 
 - A request should add or remove a **single map** to/from the rotations. Multiple changes require multiple issues. Changes to server names and other suggestions belong on the [forums](https://oc.tc/forums/4fc1d973b944ec75030002e2), not here.
-- Maps to be added must already be in the OCN [map repository](https://maps.oc.tc/). New maps should be posted to the [forums](https://oc.tc/forums/4fc17996c4637515f7000016), not here.
+- Maps to be added must already be in the OCN [map repository](https://maps.oc.tc/). New maps should be posted to the [forums](https://oc.tc/forums/53f7a8d1d7c83698b7b67499), not here.
 - Make sure your request doesn't duplicate an [existing request](https://github.com/OvercastNetwork/Rotations/issues).
 - If you want to re-submit a rejected map because it has been significantly improved, re-open the [existing issue](https://github.com/OvercastNetwork/Rotations/issues), rather than creating a new one.
 - The title of your issue should contain the type of change and the map name e.g. "Add WarWars"


### PR DESCRIPTION
Previous one did not function and linked the user to a non-existent 404 page or forum section, altered link to push user to the submission section of the map making forum.
