### PR TITLE
Remove Demesne from rotations

### DIFF
--- a/EU/Alpha
+++ b/EU/Alpha
@@ -13,7 +13,6 @@ Scrap Mettle
 Holiday Blocks
 Wildwood Crevice
 Hot Dam
-Demesne
 Merry Drought
 Avalon Funland
 Battle of Lyndanisse

--- a/EU/Deathmatch
+++ b/EU/Deathmatch
@@ -6,7 +6,6 @@ BlockBlock
 Wildwood Crevice
 Lights Out
 Tebulas
-Demesne
 Harb
 Abandoned Zoo
 Wooly Woods

--- a/US/Alpha
+++ b/US/Alpha
@@ -8,7 +8,6 @@ Lunar Coliseum
 Turf Wars
 Nuclear Winter
 Hot Dam
-Demesne
 Battle of Lyndanisse
 Festive Venice
 Merry Drought

--- a/US/Beta
+++ b/US/Beta
@@ -21,5 +21,4 @@ Harb
 Race for Victory 3
 The Nile
 Hot Dam
-Demesne
 Below Zero

--- a/US/Deathmatch
+++ b/US/Deathmatch
@@ -6,7 +6,6 @@ BlockBlock
 Wildwood Crevice
 Lights Out
 Tebulas
-Demesne
 Harb
 Abandoned Zoo
 Wooly Woods


### PR DESCRIPTION
Remove Demesne from rotations (EU Alpha, Deathmatch / US Alpha, Beta, Deathmatch

The map was added with the Advent Calendar but due to problems with spawn killing (that I attempted to fix and failed) it should be removed as soon as possible even if the event is not over. I am working on redesigning the spawn on the map.
