### PR TITLE
Suggestion remove least played map on eu conquer rots and replace them!

### DIFF
--- a/Suggestion remove least played maps on conquer rots and replace them
+++ b/Suggestion remove least played maps on conquer rots and replace them
@@ -1,0 +1,4 @@
+I rarely see like Storm and circus tdm has been played that often on eu rots and sometimes us rots mostly eu rots tho,
+so i thought i could fork a suggestion here!
+~Replace Storm with Trench Warfare 2
+~Replace Circus TDM with Rift


### PR DESCRIPTION
Lately and mostly on the europe conquer rotations i dont often see like storm are playing on conquer eu.

?Reasons?
Well the map storm are kinda boring in my opinion and maybe more people agree with me... And also there is like nobody playing conquer eu specially the map storm :(!

So i will suggest like we can replace it with a better map.

~Replace Storm with Modern Cityscape 

That's it i hope this will be changed!

~McFanta_