### PR TITLE
Remove Halloween themed levels from rotation

### DIFF
--- a/Arcade
+++ b/Arcade
@@ -17,6 +17,5 @@ Juggernaut's Hamlet
 Lunar Barrage
 Bubble Brawl: Turbine
 Creep Slap
-Block Runner: Halloween
 Dynamight Versus
 Mineth

--- a/Mini
+++ b/Mini
@@ -3,6 +3,7 @@ Warlock
 Acear I
 Assault
 Dwyer Hill
+Chimeric
 Justice
 The Grove
 Viridun FFA
@@ -38,4 +39,5 @@ Discipline
 Empire
 Facility
 Battle Ecliptica II
+Brisked
 Directrix

--- a/Mini
+++ b/Mini
@@ -9,6 +9,7 @@ The Grove
 Viridun FFA
 Dust
 Divided
+Crenel
 Persisto
 Snowy Wars
 Pharaoh's Catacombs

--- a/Mini
+++ b/Mini
@@ -1,24 +1,19 @@
-DynaboOo
+Dynamo
 Warlock
 Acear I
 Assault
 Dwyer Hill
-Abudracula
-Chimeric Horror
 Justice
-Rotten Slopes
 The Grove
 Viridun FFA
 Dust
 Divided
-Crenel Halloween
-Perspookysto
-Snowy Wars Halloween
+Persisto
+Snowy Wars
 Pharaoh's Catacombs
-SolitudeMC Halloween
-Ware-Haunted-House
+SolitudeMC
 Cargo
-Sunrise Over Lava
+Sunrise Over Paradise
 Sunburn
 Desert Cataract
 Ouroboros
@@ -26,23 +21,21 @@ Fox Mini
 Streamline
 Connected
 Deepwind Jungle
-Scareros
+Aaeros
 BlockRAGE
 Diversity
 Concourse
-Spooky Country
+Desert Country
 Woolirium
 BoomBox
-Circus DTC: Halloween
+Circus DTC
 Golden Drought III
-SuperHALLOW
-BalloonsDTM: Halloween
+SuperPRISM
+BalloonsDTM
 Coastline
 Placid Spring
 Discipline
-Empire in Ruins
+Empire
 Facility
 Battle Ecliptica II
-Brisked Halloween
-Pumpkin Madness
 Directrix

--- a/US/Capture1
+++ b/US/Capture1
@@ -1,4 +1,4 @@
-Haunted Rings
+Ring Race
 Two Tier
 Cake Day
 Tetrad
@@ -11,7 +11,7 @@ Bamboo Valley
 Fairy Tales 2: A Tale or Two
 Circus CTW
 PixelMix
-BackSPOOK
+Outback
 Golden Drought
 Fox Strife
 Belcrest
@@ -19,5 +19,4 @@ Battle Ecliptica III
 Royal Garden CTW
 Fourchette
 Turf Wars
-Spooky Smog
 Race for Victory 2

--- a/US/Capture2
+++ b/US/Capture2
@@ -1,16 +1,14 @@
 Battle Ecliptica II
-Perspookysto
-Empire in Ruins
+Persisto
+Empire
 Ouroboros
 Golden Drought III
 Banana Split II
 Woolirium
 Rooted
-Pumpkin Madness
 Cargo
 Unum Lana
 Diversity
-Spooky Country
+Desert Country
 Deepwind Jungle
 Placid Spring
-Rotten Slopes

--- a/US/Capture3
+++ b/US/Capture3
@@ -4,16 +4,15 @@ Assault
 Battle Ecliptica CTF
 SuperCUBE
 Dust CTF
-AlepBOO!
+Aleppo
 The Fenland CTF
 Larnia
 Concourse
 Palace CTF
-A SpOOky Sunset
-Deserted Sanctuary
+The Last Sunset
+Desert Sanctuary
 Lost World: CTF
 Justice
 Fruhling
-SpOOky Diamonds
 The Grove
 Acear I

--- a/US/Capture3
+++ b/US/Capture3
@@ -14,5 +14,6 @@ Desert Sanctuary
 Lost World: CTF
 Justice
 Fruhling
+Chocolate Diamonds
 The Grove
 Acear I

--- a/US/Destroy
+++ b/US/Destroy
@@ -1,15 +1,13 @@
 Iris DTC
-Spooky Garden DTC
+Royal Garden DTC
 Battle of Krehm
 Retaliation
 Bamboo Valley III
-Fallencrests: Halloween
-SSB Halloween
-Haunted Blocks
+Fallencrests
+Spaceship Battles
+Blocks DTC
 DATAbasin
-Halloween Train
-Celestial Twilight
-Nuclear Halloween
+Midnight Train
 Fractal Descent
 Ion
 Totally War II


### PR DESCRIPTION
This also adds Chimeric, SolitudeMC, Brisked and Chocolate Diamonds into the rotation which all have highly rated Halloween variants.