### PR TITLE
Updated Mini Rotations

### DIFF
--- a/Mini
+++ b/Mini
@@ -6,19 +6,19 @@ Dwyer Hill
 Chimeric
 Justice
 The Grove
+Ouroboros
 Viridun FFA
 Dust
 Divided
 Crenel
 Persisto
 Snowy Wars
-Pharaoh's Catacombs
+To
 SolitudeMC
 Cargo
 Sunrise Over Paradise
 Sunburn
 Desert Cataract
-Ouroboros
 Fox Mini
 Streamline
 Connected
@@ -34,7 +34,7 @@ Circus DTC
 Golden Drought III
 SuperPRISM
 BalloonsDTM
-Coastline
+Pharaoh's Catacombs
 Placid Spring
 Discipline
 Empire


### PR DESCRIPTION
Re-arranged rotation, put a CTW map between the maps with no objectives, so that it won't "bore" players. Removed Coastline, and added To, which brings a more unique map into the rotations.